### PR TITLE
raise a specially typed exception for mailing ID error

### DIFF
--- a/lib/action_kit_rest/response/raise_error.rb
+++ b/lib/action_kit_rest/response/raise_error.rb
@@ -6,7 +6,12 @@ module ActionKitRest
         status_code = response[:status].to_i
         if (400...600).include? status_code
           if status_code == 400
-            raise ActionKitRest::Response::ValidationError.new(url: response[:url].to_s, body: response[:body])
+            response_body = response[:body]
+            if JSON.parse(response_body)['errors'] = {'mailing_id' => ['Unable to associate this mailing ID with account.']}
+              raise ActionKitRest::Response::InvalidAkidError.new(url: response[:url].to_s, body: response_body)
+            else
+              raise ActionKitRest::Response::ValidationError.new(url: response[:url].to_s, body: response_body)
+            end
           elsif status_code == 404
             raise ActionKitRest::Response::NotFound.new(response[:url].to_s)
           elsif status_code == 401

--- a/lib/action_kit_rest/response/raise_error.rb
+++ b/lib/action_kit_rest/response/raise_error.rb
@@ -7,7 +7,7 @@ module ActionKitRest
         if (400...600).include? status_code
           if status_code == 400
             response_body = response[:body]
-            if JSON.parse(response_body)['errors'] = {'mailing_id' => ['Unable to associate this mailing ID with account.']}
+            if JSON.parse(response_body)['errors'] == {'mailing_id' => ['Unable to associate this mailing ID with account.']}
               raise ActionKitRest::Response::InvalidAkidError.new(url: response[:url].to_s, body: response_body)
             else
               raise ActionKitRest::Response::ValidationError.new(url: response[:url].to_s, body: response_body)

--- a/lib/action_kit_rest/response/validation_error.rb
+++ b/lib/action_kit_rest/response/validation_error.rb
@@ -13,7 +13,9 @@ module ActionKitRest
       def to_s
         "#{super()} \n url: #{url} \n body: #{body} \n errors: #{errors}"
       end
-      
+    end
+
+    class InvalidAkidError < ValidationError
     end
   end
 end

--- a/spec/lib/action_kit_rest/page_spec.rb
+++ b/spec/lib/action_kit_rest/page_spec.rb
@@ -83,6 +83,15 @@ describe ActionKitRest::Page do
         end  
       end
 
+      describe 'mailing ID error' do
+        let(:status) { 400 }
+        let(:body) { '{"errors": {"mailing_id": ["Unable to associate this mailing ID with account."]}}' }
+
+        it "should raise an Invalid AKID response error" do
+          lambda{ subject.page.get(1) }.should raise_exception(ActionKitRest::Response::InvalidAkidError)
+        end
+      end
+
       describe "an error" do
         let(:status) { 500 }
 


### PR DESCRIPTION
This enhances the error handling code to specifically detect the error response `{"errors": {"mailing_id": ["Unable to associate this mailing ID with account."]}}` and raise a specially typed exception. The idea is that callers can handle this exception in some appropriate way (e.g. by retrying the call without the problematic `akid`).