### PR TITLE
Strip unsupported characters before making create and update requests

### DIFF
--- a/lib/action_kit_rest/base.rb
+++ b/lib/action_kit_rest/base.rb
@@ -10,14 +10,15 @@ module ActionKitRest
     end
 
     def create(params)
-      params.each { |k, v| params[k] = strip_unsupported_characters(v) }
-      resp = client.post_json_request(normalized_base_path, params)
+      cleaned_params = clean_params(params)
+      resp = client.post_json_request(normalized_base_path, cleaned_params)
       id = extract_id_from_response(resp)
       get(id)
     end
 
     def update(id, params)
-      client.put_json_request("#{normalized_base_path}#{url_escape(id)}/", params)
+      cleaned_params = clean_params(params)
+      client.put_json_request("#{normalized_base_path}#{url_escape(id)}/", cleaned_params)
       get(id)
     end
 
@@ -40,8 +41,18 @@ module ActionKitRest
     end
 
     def strip_unsupported_characters(string)
-      # ActionKit only supports three-byte UTF-8 for many fields.
       string.each_char.select{|c| c.bytes.count <= 3 }.join('')
+    end
+
+    # ActionKit only supports three-byte UTF-8 for many fields.
+    def clean_params(params)
+      cleaned_params = {}
+      params.each do |k, v|
+        if v.is_a? String
+          cleaned_params[k] = strip_unsupported_characters(v)
+        end
+      end
+      cleaned_params
     end
   end
 end

--- a/lib/action_kit_rest/base.rb
+++ b/lib/action_kit_rest/base.rb
@@ -10,6 +10,7 @@ module ActionKitRest
     end
 
     def create(params)
+      params.each { |k, v| params[k] = strip_unsupported_characters(v) }
       resp = client.post_json_request(normalized_base_path, params)
       id = extract_id_from_response(resp)
       get(id)
@@ -36,6 +37,11 @@ module ActionKitRest
 
     def extract_id_from_location(location)
       location.scan(/\/(\d+)\/$/).first.first
+    end
+
+    def strip_unsupported_characters(string)
+      # ActionKit only supports three-byte UTF-8 for many fields.
+      string.each_char.select{|c| c.bytes.count <= 3 }.join('')
     end
   end
 end

--- a/lib/action_kit_rest/pages/base.rb
+++ b/lib/action_kit_rest/pages/base.rb
@@ -6,7 +6,7 @@ module ActionKitRest
         response = list(name: name)
         response.obj.first
       end
-      
+
       def find_or_create(params)
         page = find(params[:name])
         if page.blank?

--- a/spec/lib/action_kit_rest/pages/event_campaign_page_spec.rb
+++ b/spec/lib/action_kit_rest/pages/event_campaign_page_spec.rb
@@ -36,6 +36,15 @@ describe ActionKitRest::Pages::EventCampaignPage do
       expect(a_request(:get, 'https://test.com/rest/v1/campaign/88/')).to have_been_made
     end
 
+    it 'should handle not-allowed characters when creating an event campaign' do
+      resp = actionkit.event_campaign_page.create({title: 'Climate Change Paris 2015🌿', name: 'climate-change-paris-2015', event_pages_tags: ['/rest/v1/tag/1/', '/rest/v1/tag/5/']})
+      expect(resp.title).to eq event_campaign_title
+      expect(resp.name).to eq event_campaign_name
+
+      expect(a_request(:post, 'https://test.com/rest/v1/campaign/')).to have_been_made
+      expect(a_request(:get, 'https://test.com/rest/v1/campaign/88/')).to have_been_made
+    end
+
     it 'should create associated event and signup create pages' do
       resp = actionkit.event_campaign_page.create({title: 'Climate Change Paris 2015', name: 'climate-change-paris-2015', event_pages_tags: ['/rest/v1/tag/1/', '/rest/v1/tag/5/']})
       expect(resp.event_create_page_name).to eq 'climate-change-paris-2015-event-create'

--- a/spec/lib/action_kit_rest/pages/import_page_spec.rb
+++ b/spec/lib/action_kit_rest/pages/import_page_spec.rb
@@ -24,6 +24,11 @@ describe ActionKitRest::Pages::ImportPage do
         resp = actionkit.import_page.create(title: "Title", name: "name")
         expect(resp.title).to eq 'Demand a Sustainable USDA'
       end
+
+      it "should strip not-allowed characters from params" do
+        resp = actionkit.import_page.create(title: "Title😭", name: "name🦷")
+        expect(resp.title).to eq 'Demand a Sustainable USDA'
+      end
     end
   end
 

--- a/spec/lib/action_kit_rest/pages/import_page_spec.rb
+++ b/spec/lib/action_kit_rest/pages/import_page_spec.rb
@@ -49,6 +49,11 @@ describe ActionKitRest::Pages::ImportPage do
         resp = actionkit.import_page.update('1093', title: "Title", name: "name")
         expect(resp.title).to eq 'Demand a Sustainable USDA'
       end
+
+      it "should strip not-allowed characters from params" do
+        resp = actionkit.import_page.update('1093', title: "Title🌈", name: "name🍅")
+        expect(resp.title).to eq 'Demand a Sustainable USDA'
+      end
     end
   end
 end


### PR DESCRIPTION
For many fields, ActionKit only supports UTF-8 characters up to three bytes, so we remove characters with more than three bytes (e.g., most emojis)