### PR TITLE
handle Encoding::CompatibilityError trying to construct error message

### DIFF
--- a/lib/action_kit_rest/response/validation_error.rb
+++ b/lib/action_kit_rest/response/validation_error.rb
@@ -11,7 +11,14 @@ module ActionKitRest
       end
 
       def to_s
-        "#{super()} \n url: #{url} \n body: #{body} \n errors: #{errors}"
+        begin
+          "#{super()} \n url: #{url} \n body: #{body} \n errors: #{errors}"
+        rescue Encoding::CompatibilityError
+          # Something went gravely wrong trying to construct the error message, so give up on the extra info
+          # and just raise the name of the exception.
+          # This will let us at least raise with a backtrace.
+          super
+        end
       end
     end
 


### PR DESCRIPTION
We're hoping this will work around https://rollbar.com/ChangeSproutInc./agra/items/21/ to let us see where the underlying error is happening, even if we can't see the full details of the error message from ActionKit.

No specs included, because I couldn't figure out how to make this error happen, but the existing specs around the normal operation of ValidationError do pass.