### PR TITLE
Fix encoding errors when error response is in ASCII-8BIT encoding

### DIFF
--- a/lib/action_kit_rest/response/validation_error.rb
+++ b/lib/action_kit_rest/response/validation_error.rb
@@ -13,7 +13,7 @@ module ActionKitRest
       end
 
       def to_s
-        "#{super()} \n url: #{url} \n body: #{body} \n errors: #{errors}"
+        "#{super()} \n url: #{url} \n body: #{body.force_encoding('UTF-8')} \n errors: #{errors}"
       rescue Encoding::CompatibilityError
         # Something went gravely wrong trying to construct the error message, so give up on the extra info
         # and just raise the name of the exception.

--- a/spec/lib/action_kit_rest/response/validation_error_spec.rb
+++ b/spec/lib/action_kit_rest/response/validation_error_spec.rb
@@ -25,5 +25,15 @@ describe ActionKitRest::Response::ValidationError do
         expect(subject.to_s).to eq "ActionKitRest::Response::ValidationError \n url: #{url} \n body: #{body} \n errors: #{errors.inspect}"
       end
     end
+
+    context 'with a body in ASCII-8BIT format' do
+      let(:url) { 'https://actionkit.example.com/rest/v1/page/1' }
+      let(:errors) { {'mailing_id' => ['לא הצלחנו לקשר בין מספר הזיהוי של רשימת הדיוור הזו לבין החשבון.']} }
+      let(:body) { { errors: errors }.to_json.b }
+
+      it 'should put information in the string' do
+        expect(subject.to_s).to eq "ActionKitRest::Response::ValidationError \n url: #{url} \n body: {\"errors\":#{errors.to_json}} \n errors: #{errors.inspect}"
+      end
+    end
   end
 end


### PR DESCRIPTION
This solves a problem we have where some error responses from ActionKit are treated as ASCII-8BIT encoding instead of UTF-8, which cased an Encoding::CompatibilityError when we tried to render the error string, which meant that instances like https://rollbar.com/ChangeSproutInc./agra/items/3904/occurrences/184553557018/ sent no useful information to Rollbar.

In my tests in the Rails console on production, this solved the issue and I was able to see that for this particular error for Zazim, the response is Hebrew for "We were unable to link the ID of this mailing list to the account".